### PR TITLE
Print strings returned by read as-is

### DIFF
--- a/examples/mock_docker.rb
+++ b/examples/mock_docker.rb
@@ -139,8 +139,7 @@ class Volume < Wash::Entry
   # Note that you are not required to define a constructor for
   # every entry class; this example only does so out of the
   # author's personal preference. To emphasize this point, notice
-  # how the VolumeDir/VolumeFile classes do not have an initialize
-  # method.
+  # how the VolumeDir class does not have an initialize method.
   def initialize(name)
     @name = name
   end
@@ -149,8 +148,7 @@ class Volume < Wash::Entry
     dir = VolumeDir.new
     dir.name = "dir"
 
-    file = VolumeFile.new
-    file.name = "file"
+    file = VolumeFile.new("file")
 
     [dir, file]
   end
@@ -161,17 +159,24 @@ class VolumeDir < Wash::Entry
   parent_of 'VolumeDir', 'VolumeFile'
 
   def list
-    file = VolumeFile.new
-    file.name = "file_in_dir"
+    file = VolumeFile.new("file_in_dir")
     [file]
   end
 end
 
 class VolumeFile < Wash::Entry
   label 'mock_volume_file'
+  attributes :size
+  state :content
+
+  def initialize(name)
+    @name = name
+    @content = "Reading #{@name}'s content"
+    @size = @content.size
+  end
 
   def read
-    "Reading #{@name}'s content"
+    @content
   end
 end
 

--- a/lib/wash/method.rb
+++ b/lib/wash/method.rb
@@ -29,9 +29,12 @@ module Wash
     private_class_method :method
 
     method(:list)
-    method(:read)
     method(:metadata)
     method(:schema)
+
+    method(:read) do |entry, _|
+      STDOUT.print(entry.read)
+    end
 
     method(:exec) do |entry, *args|
       opts, cmd, args = Wash.send(:parse_json, args[0]), args[1], args[2..-1]

--- a/lib/wash/streamer.rb
+++ b/lib/wash/streamer.rb
@@ -17,7 +17,7 @@ module Wash
           puts("200")
           @first_chunk = false
         end
-        print(chunk)
+        STDOUT.print(chunk)
         STDOUT.flush
     end
   end


### PR DESCRIPTION
This way, read's content won't be truncated by the JSON string's quotes.

This commit also updates the mock_docker example to set the size attribute
for Volume::File so that we have a test for this bug.

Signed-off-by: Enis Inan <enis.inan@puppet.com>