### PR TITLE
Fix name of enable_schema_prefetching in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ require 'wash'
 # before the subsequent Wash.run call
 #Wash.pretty_print
 #Wash.enable_entry_schemas
-#Wash.enable_schema_prefetching
+#Wash.prefetch_entry_schemas
 
 Wash.run(<root_klass>, ARGV)
 


### PR DESCRIPTION
The README used the wrong function name.

Signed-off-by: Michael Smith <michael.smith@puppet.com>