### PR TITLE
Fix the docs link

### DIFF
--- a/lib/wash.rb
+++ b/lib/wash.rb
@@ -92,7 +92,7 @@ module Wash
 
   def self.next_arg(argv)
     if argv.size < 1
-      raise "Invalid plugin-script invocation. See https://puppetlabs.github.io/wash/docs/external_plugins/ for details on what this should look like"
+      raise "Invalid plugin-script invocation. See https://puppetlabs.github.io/wash/docs/external-plugins for details on what this should look like"
     end
     return argv[0], argv[1..-1]
   end


### PR DESCRIPTION
Was renamed from external_plugins to external-plugins.

Signed-off-by: Michael Smith <michael.smith@puppet.com>