### PR TITLE
Ensure output is unbuffered for exec and stream

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -1,0 +1,29 @@
+name: Ruby Gem
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby 2.6
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.6'
+
+    - name: Publish to RubyGems
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem build *.gemspec
+        gem push *.gem
+      env:
+        GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,3 @@ jobs:
     - curl -sfL https://github.com/puppetlabs/wash/releases/download/0.17.0/wash-0.17.0-x86_64-unknown-linux.tgz | tar -xz
     script:
     - ./wash validate examples/mock_docker.rb
-  - stage: gem release
-    name: Deploy to RubyGems
-    script: echo "Deploying to rubygems.org..."
-    deploy:
-      provider: rubygems
-      api_key:
-        secure: UmW0wVdmrN8hUxej4vPqopgueWEpIQKhSxse5u1QW5Ki9JV1qwEmTy2KZOeaXANfbRCPT3uMfW7JQxvvIF5YG0yk4HlWUxgUQIhgTgzK5VwOIKgXvxZXskuPhuPqcNM98MqQTsmVvO54JnIRENz1C8RCpDPERtJwLmOtGrbwdgLw0cSU7CkHa2yTvdDhKsQPzRxvVtVqMGQ67LOJmp+IDmcy5jAzYsiYu7udlPsHCI5FeRNiUWg27MHRYAOQ7ZxoACs4gpZ64UXyxyXJdQ7eLZ9YjFBYnZ8Z0wRfuGG9FDil8hDSQ1Hg4WUdmWSZpUW49vU531txUKKe3IFwhokf2zhvu/0+BgvydaViWqZ50jz3G9lywert0JN3U1YKSjMeZOy53Uq2QuUtjqYxNKkjgiELMbt8dLVVK3tmkO9HhXvLsje2GWn+MNd5fiun0yrN2pLrYuAkQMYrBvXZEpwFnw5x3G7kkMH9EtmWVJWj8H+piKnUxhd3yVjaAPgU3CBP6QLedP07bH/S5s4in0SfhrkvZ4T9K3N3Cr02OGGPB+UuFW5ioqssCJoPBOVirSU43F/XLJbbEjJC1p8MPSaQzF+9Sbap1d4T780MWreJfw9I46h1FJv2T6s6vkelrsBeqh11HiKReoMS7KV52eG7xuSo6MshznlbWYoUKSPMCT4=
-      gem: wash
-      on:
-        repo: puppetlabs/wash-ruby
-        tags: true

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ implements `stream` and `exec`. The calling conventions and return parameters fo
 
 * `metadata` should return a `Hash` containing the entry's full metadata.
 
-* `stream` should never return during normal operation. `stream` implementations should use the `Wash::Streamer` class when writing their chunks
+* `stream` should never return during normal operation. `stream` implementations should use the `Wash::Streamer` class when writing their chunks.
 
-* `exec(cmd, args, opts)` should return `cmd`'s exit code. `exec` implementations should write their stdout/stderr chunks to stdout/stderr. Note that `STDIN`, if provided, can be accessed via the `opts[:stdin]` key.
+* `exec(cmd, args, opts)` should return `cmd`'s exit code. `exec` implementations should write their stdout/stderr chunks to stdout/stderr. Note that `STDIN`, if provided, can be accessed via the `opts[:stdin]` key. When this function is called, Wash sets `sync=true` for `$stdout` and `$stdout` to ensure output is immediately available.
 
 * `delete` should return `true` if the entry was deleted, `false` if the entry's deletion is in progress.
 

--- a/lib/wash/method.rb
+++ b/lib/wash/method.rb
@@ -50,6 +50,8 @@ module Wash
     end
 
     method(:exec) do |entry, *args|
+      $stdout.sync = true
+      $stderr.sync = true
       opts, cmd, args = Wash.send(:parse_json, args[0]), args[1], args[2..-1]
       if opts[:stdin]
         opts[:stdin] = $stdin

--- a/wash.gemspec
+++ b/wash.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "wash"
-  spec.version       = "0.4.0"
+  spec.version       = "0.4.1"
   spec.authors       = ["Puppet"]
   spec.email         = ["puppet@puppet.com"]
 


### PR DESCRIPTION
Exec intentionally streams to stdout/stderr. Ensure these are unbuffered so that we get immediate updates.

Stream doesn't need changes because Wash::Streamer already flushes after writing each chunk.

Fixes #32.

Signed-off-by: Michael Smith <michael.smith@puppet.com>